### PR TITLE
Bug in the "The Lost" quest

### DIFF
--- a/DominikGamer
+++ b/DominikGamer
@@ -1,0 +1,2 @@
+I lost three of those letters what I need to do the quest. When I type /fixquests
+I do not get them back those letters and I can't finish the quest. Please fix bug. Sorry for my bad English.


### PR DESCRIPTION
I lost three of those letters what I need to do the quest. When I type /fixquests
I do not get them back those letters and I can't finish the quest. Please fix bug. Sorry for my bad English.
